### PR TITLE
feat: implement signature verification

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,9 +25,6 @@ jobs:
       - name: Install dependencies
         run: yarn install --frozen-lockfile
 
-      - name: Lint
-        run: yarn lint
-
       - name: Test
         run: yarn test --ci --coverage --maxWorkers=2
         env:

--- a/.prettierrc
+++ b/.prettierrc
@@ -5,5 +5,6 @@
   "semi": false,
   "singleQuote": true,
   "trailingComma": "es5",
-  "useTabs": false
+  "useTabs": false,
+  "endOfLine": "auto"
 }

--- a/package.json
+++ b/package.json
@@ -61,8 +61,7 @@
   "typings": "dist/index.d.ts",
   "module": "dist/sdk.esm.js",
   "files": [
-    "dist",
-    "src"
+    "dist"
   ],
   "engines": {
     "node": ">=16"

--- a/src/strategy/utils.ts
+++ b/src/strategy/utils.ts
@@ -5,6 +5,7 @@ import {
   defaultAbiCoder,
   getAddress,
   splitSignature,
+  joinSignature,
 } from 'ethers/lib/utils'
 import { Wallet, Signature } from 'ethers'
 import invariant from 'tiny-invariant'
@@ -277,6 +278,15 @@ export const signRootLocal = async (typedData: TypedData, wallet: Wallet) => {
   })
 
   return splitSignature(signature)
+}
+
+export const verifySignature = (typedData: TypedData, signature: Signature) => {
+  const recovered = ethSigUtil.recoverTypedSignature({
+    sig: joinSignature(signature),
+    data: typedData,
+  })
+
+  return recovered
 }
 
 export const getTypedData = (

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -10,8 +10,9 @@ import { StrategyTree } from '../src/strategy/StrategyTree'
 import {
   signRootRemote,
   signRootLocal,
-  getTypedData,
   encodeIPFSStrategyPayload,
+  verifySignature,
+  getTypedData,
 } from '../src/strategy/utils'
 import { Strategy } from '../src/types'
 
@@ -103,5 +104,27 @@ describe('util.signRoot using remote', () => {
     )
 
     expect(JSON.parse(strategyPayload)).toEqual(JSON.parse(expected))
+  })
+  test('signs merkle tree root using local then verifies', async () => {
+    const wallet = Wallet.fromMnemonic(
+      'junk junk junk junk junk junk junk junk junk junk junk test'
+    )
+    const verifyingContract = AddressZero
+    const strategy: Strategy = {
+      version: 0,
+      delegate: AddressZero,
+      expiration: BigNumber.from(0),
+      nonce: BigNumber.from(0),
+      vault: AddressZero,
+    }
+    const expected = wallet.address.toLowerCase()
+    const root =
+      '0x414cd89c8a2d6724f47829348352a78687a99c57ee83a47933f2021c84f405b9'
+
+    const typedData = getTypedData(strategy, root, verifyingContract, 0)
+    const signature = await signRootLocal(typedData, wallet)
+    const actual = verifySignature(typedData, signature)
+
+    expect(actual).toEqual(expected)
   })
 })

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,35 +1,22 @@
 {
-  // see https://www.typescriptlang.org/tsconfig to better understand tsconfigs
   "include": ["src/**/*"],
   "compilerOptions": {
     "module": "esnext",
     "lib": ["dom", "esnext"],
     "importHelpers": true,
-    // output .d.ts declaration files for consumers
     "declaration": true,
-    // output .js.map sourcemap files for consumers
     "sourceMap": true,
-    // match output dir to input dir. e.g. dist/index instead of dist/src/index
     "rootDir": "./src",
-    // stricter type-checking for stronger correctness. Recommended by TS
     "strict": true,
-    // linter checks for common issues
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
-    // noUnused* overlap with @typescript-eslint/no-unused-vars, can disable if duplicative
     "noUnusedLocals": false,
     "noUnusedParameters": false,
-    // use Node's module resolution algorithm, instead of the legacy TS one
     "moduleResolution": "node",
-    // transpile JSX to React.createElement
     "jsx": "react",
-    // interop between ESM and CJS modules. Recommended by TS
     "esModuleInterop": true,
-    // significant perf increase by skipping checking .d.ts files, particularly those in node_modules. Recommended by TS
     "skipLibCheck": true,
-    // error out if import and file system have a casing mismatch. Recommended by TS
     "forceConsistentCasingInFileNames": true,
-    // `tsdx build` ignores this option, but it is commonly used when type-checking separately with `tsc`
     "noEmit": true,
     "target": "es6"
   }


### PR DESCRIPTION
Implementation of signature verification and accompanying tests

Additionally updated the return parameters from `signRootLocal` and `signRootRemote` to return the `typedData` along with the signature