### PR TITLE
fix: unchecksum all addresses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,27 +1,24 @@
 # [1.0.0-alpha.23](https://github.com/astariaxyz/astaria-sdk/compare/v1.0.0-alpha.22...v1.0.0-alpha.23) (2023-03-17)
 
-
 ### Bug Fixes
 
-* replace ganache with ethereum-waffle ([f7b4a06](https://github.com/astariaxyz/astaria-sdk/commit/f7b4a06e0759699bf18583743b1c30e02057e569))
-* replace ganache with ethereum-waffle ([aa568a7](https://github.com/astariaxyz/astaria-sdk/commit/aa568a71f248d0f1ed74c34fe72062409466089b))
-* unique offer path ([bda90b9](https://github.com/astariaxyz/astaria-sdk/commit/bda90b9a1eb42b7730b99a92c88c11e67c81558f))
-
+- replace ganache with ethereum-waffle ([f7b4a06](https://github.com/astariaxyz/astaria-sdk/commit/f7b4a06e0759699bf18583743b1c30e02057e569))
+- replace ganache with ethereum-waffle ([aa568a7](https://github.com/astariaxyz/astaria-sdk/commit/aa568a71f248d0f1ed74c34fe72062409466089b))
+- unique offer path ([bda90b9](https://github.com/astariaxyz/astaria-sdk/commit/bda90b9a1eb42b7730b99a92c88c11e67c81558f))
 
 ### Features
 
-* implement changes for a queueing system ([bac7324](https://github.com/astariaxyz/astaria-sdk/commit/bac73248ff5c26d250653864168fceb28dc3d451))
-* increase test timeout ([c9f8fec](https://github.com/astariaxyz/astaria-sdk/commit/c9f8fec38f9352a8c2b509978333430ece6a0171))
-* increase timeouts ([7c84ac4](https://github.com/astariaxyz/astaria-sdk/commit/7c84ac4d6ee138b9f4cd17bf3bfe67a5f9042bfd))
-* lift timeout into describe block ([e018d96](https://github.com/astariaxyz/astaria-sdk/commit/e018d965c7eddf5f0cd2c5754e8e3c2f71d0a864))
+- implement changes for a queueing system ([bac7324](https://github.com/astariaxyz/astaria-sdk/commit/bac73248ff5c26d250653864168fceb28dc3d451))
+- increase test timeout ([c9f8fec](https://github.com/astariaxyz/astaria-sdk/commit/c9f8fec38f9352a8c2b509978333430ece6a0171))
+- increase timeouts ([7c84ac4](https://github.com/astariaxyz/astaria-sdk/commit/7c84ac4d6ee138b9f4cd17bf3bfe67a5f9042bfd))
+- lift timeout into describe block ([e018d96](https://github.com/astariaxyz/astaria-sdk/commit/e018d965c7eddf5f0cd2c5754e8e3c2f71d0a864))
 
 # [1.0.0-alpha.22](https://github.com/astariaxyz/astaria-sdk/compare/v1.0.0-alpha.21...v1.0.0-alpha.22) (2023-03-14)
 
-
 ### Features
 
-* config module, resolve circular dependency ([aa8e3bb](https://github.com/astariaxyz/astaria-sdk/commit/aa8e3bbf749b76cfec16ab7c64283cbc0a8e1d92))
-* dynamic runtime configuration ([781755e](https://github.com/astariaxyz/astaria-sdk/commit/781755e6eec11f002a2871475bc35f69598fdea5))
+- config module, resolve circular dependency ([aa8e3bb](https://github.com/astariaxyz/astaria-sdk/commit/aa8e3bbf749b76cfec16ab7c64283cbc0a8e1d92))
+- dynamic runtime configuration ([781755e](https://github.com/astariaxyz/astaria-sdk/commit/781755e6eec11f002a2871475bc35f69598fdea5))
 
 # [1.0.0-alpha.21](https://github.com/astariaxyz/astaria-sdk/compare/v1.0.0-alpha.20...v1.0.0-alpha.21) (2023-03-03)
 

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "merkletreejs": "^0.3.9",
     "papaparse": "^5.3.2",
     "tiny-invariant": "^1.2.0",
-    "zod": "^3.20.2"
+    "zod": "^3.21.4"
   },
   "devDependencies": {
     "@commitlint/config-conventional": "^17.3.0",

--- a/src/types/helpers.ts
+++ b/src/types/helpers.ts
@@ -4,7 +4,7 @@ import { BigNumber } from 'ethers'
 export const SignedHexSchema = z.string().regex(/^[-]{0,1}0x[a-fA-F0-9]*$/)
 
 export const HexSchema = z.string().regex(/^0x[a-fA-F0-9]*$/)
-export const AddressSchema = HexSchema.length(42)
+export const AddressSchema = HexSchema.toLowerCase().length(42)
 
 export const WAD = BigNumber.from('1000000000000000000')
 

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -101,7 +101,7 @@ describe('util.signRoot using remote', () => {
       strategyTree.getStrategy
     )
     const actual = await Hash.of(strategyPayload)
-    const expected = 'QmYLBCxovAacZd58rNxV6GcmqbJkVnTGePMYN9EYnLBDKy'
+    const expected = 'QmcmhWBwtLnhDjbJPcAtKeaV6EmaANedbdYLUdGf9hXF36'
 
     expect(actual).toEqual(expected)
   })

--- a/yarn.lock
+++ b/yarn.lock
@@ -10518,7 +10518,7 @@ yocto-queue@^0.1.0:
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
 
-zod@^3.20.2:
-  version "3.20.2"
-  resolved "https://registry.yarnpkg.com/zod/-/zod-3.20.2.tgz#068606642c8f51b3333981f91c0a8ab37dfc2807"
-  integrity sha512-1MzNQdAvO+54H+EaK5YpyEy0T+Ejo/7YLHS93G3RnYWh5gaotGHwGeN/ZO687qEDU2y4CdStQYXVHIgrUl5UVQ==
+zod@^3.21.4:
+  version "3.21.4"
+  resolved "https://registry.yarnpkg.com/zod/-/zod-3.21.4.tgz#10882231d992519f0a10b5dd58a38c9dabbb64db"
+  integrity sha512-m46AKbrzKVzOzs/DZgVnG5H55N1sv1M8qZU3A8RIKbs3mrACDNeIOeilDymVb2HdmP8uwshOCF4uJ8uM9rCqJw==


### PR DESCRIPTION
Client and API are breaking when provided a checksummed address in URLs