### PR TITLE
fix: convert OfferRouter to hook etc

### DIFF
--- a/src/router/OfferRouter.ts
+++ b/src/router/OfferRouter.ts
@@ -289,7 +289,7 @@ export class OfferRouter {
     )
   }
 
-  private static generateStateForOfferView(
+  public static generateStateForOfferView(
     offerBounds: OfferBounds | undefined,
     offerParams: OfferParams | undefined,
     dynamicVaultDetails: Map<string, DynamicVaultDetail>,


### PR DESCRIPTION
exposing static method to make the `OfferRouter` use hooks