### PR TITLE
Helper type refinements

### DIFF
--- a/src/strategy/utils.ts
+++ b/src/strategy/utils.ts
@@ -11,6 +11,7 @@ import {
 import axios from 'axios'
 import { parse as parseCSV } from 'papaparse'
 import invariant from 'tiny-invariant'
+import { z } from 'zod'
 
 import { getConfig } from '../config'
 
@@ -36,6 +37,7 @@ import {
   EthersTypedData,
   EthersTypedDataSchema,
 } from '../types'
+import { HexSchema } from '../types/helpers'
 
 const stringify = require('json-stringify-deterministic')
 
@@ -174,17 +176,17 @@ export const prepareLeaves = (strategy: Strategy): string[] => {
   return strategy.map((row: StrategyRow) => {
     switch (row.type) {
       case StrategyLeafType.Collection: {
-        row.leaf = keccak256(encodeCollection(row))
+        row.leaf = HexSchema.parse(keccak256(encodeCollection(row)))
         break
       }
 
       case StrategyLeafType.Collateral: {
-        row.leaf = keccak256(encodeCollateral(row))
+        row.leaf = HexSchema.parse(keccak256(encodeCollateral(row)))
         break
       }
 
       case StrategyLeafType.UniV3Collateral: {
-        row.leaf = keccak256(encodeUniV3Collateral(row))
+        row.leaf = HexSchema.parse(keccak256(encodeUniV3Collateral(row)))
         break
       }
     }
@@ -235,7 +237,7 @@ export const verifySignature = (typedData: TypedData, signature: Signature) => {
 
 export const getTypedData = (
   strategy: StrategyDetails,
-  root: string,
+  root: z.infer<typeof HexSchema>,
   verifyingContract: string,
   chainId: number
 ): TypedData => {

--- a/src/types/helpers.ts
+++ b/src/types/helpers.ts
@@ -1,10 +1,18 @@
 import { z } from 'zod'
 import { BigNumber } from 'ethers'
 
-export const SignedHexSchema = z.string().regex(/^[-]{0,1}0x[a-fA-F0-9]*$/)
+export const SignedHexSchema = z.custom<`${'-' | ''}0x${string}`>(
+  (val) => typeof val === 'string' && /^[-]{0,1}0x[a-fA-F0-9]*$/.test(val)
+)
 
-export const HexSchema = z.string().regex(/^0x[a-fA-F0-9]*$/)
-export const AddressSchema = HexSchema.toLowerCase().length(42)
+export const HexSchema = z.custom<`0x${string}`>(
+  (val) => typeof val === 'string' && /^0x[a-fA-F0-9]*$/.test(val)
+)
+
+export const AddressSchema = HexSchema.refine(
+  (val) => val.length === 42,
+  'Invalid address length'
+).transform((val) => val.toLowerCase())
 
 export const WAD = BigNumber.from('1000000000000000000')
 

--- a/src/types/helpers.ts
+++ b/src/types/helpers.ts
@@ -85,12 +85,22 @@ export const IntBigNumberSchema = z.union([
   IntStringToBigNumberSchema,
 ])
 
+const UINT8MAX = 2 ** 8 - 1
 const UINT24MAX = BigNumber.from(2).pow(24).sub(1)
 const UINT128MAX = BigNumber.from(2).pow(128).sub(1)
 const UINT256MAX = BigNumber.from(2).pow(256).sub(1)
 
 const INT24MIN = BigNumber.from(0).sub(UINT24MAX.div(2)).sub(1)
 const INT24MAX = BigNumber.from(0).add(UINT24MAX.div(2))
+
+export const Uint8Schema = z
+  .union([z.string(), z.number()])
+  .transform((val) => (typeof val === 'number' ? val : Number.parseFloat(val)))
+  .refine(
+    (val) => Number.isInteger(val) && val >= 0,
+    'Must be a positive integer'
+  )
+  .refine((val) => val <= UINT8MAX, 'Cannot exceed (2^8) - 1')
 
 export const Uint24Schema = UintBigNumberSchema.refine((val) => {
   return val instanceof BigNumber ? val.lte(UINT24MAX) : false

--- a/test/helpers.test.ts
+++ b/test/helpers.test.ts
@@ -1,0 +1,36 @@
+import { Uint8Schema } from '../src/types/helpers'
+import { ZodError } from 'zod'
+
+describe('helpers', () => {
+  test('Uint8Schema', async () => {
+    expect(Uint8Schema.parse(1)).toEqual(1)
+    expect(Uint8Schema.parse('2')).toEqual(2)
+    expect(Uint8Schema.parse(255)).toEqual(255)
+    try {
+      Uint8Schema.parse(256)
+    } catch (e: any) {
+      expect(e).toBeInstanceOf(ZodError)
+      expect((e as ZodError).errors[0].message).toEqual(
+        'Cannot exceed (2^8) - 1'
+      )
+    }
+
+    try {
+      Uint8Schema.parse('-1')
+    } catch (e: any) {
+      expect(e).toBeInstanceOf(ZodError)
+      expect((e as ZodError).errors[0].message).toEqual(
+        'Must be a positive integer'
+      )
+    }
+
+    try {
+      Uint8Schema.parse('1.2')
+    } catch (e: any) {
+      expect(e).toBeInstanceOf(ZodError)
+      expect((e as ZodError).errors[0].message).toEqual(
+        'Must be a positive integer'
+      )
+    }
+  })
+})

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -14,6 +14,7 @@ import {
   getTypedData,
 } from '../src/strategy/utils'
 import { StrategyDetails } from '../src/types'
+import { HexSchema } from '../src/types/helpers'
 
 const Hash = require('ipfs-only-hash')
 
@@ -84,7 +85,7 @@ describe('util.signRoot using remote', () => {
     const csv = await readFile(join(__dirname, '__mocks__/test.csv'), 'utf8')
     const strategyTree = StrategyTree.fromCSV(csv)
 
-    const root = strategyTree.getHexRoot()
+    const root = HexSchema.parse(strategyTree.getHexRoot())
     const wallet = Wallet.fromMnemonic(sharedMnemonic)
     const verifyingContract = AddressZero
     const strategy: StrategyDetails = {


### PR DESCRIPTION
* Updates `SignedHexSchema`, `HexSchema` and `AddressSchema` to return more refined types that start with `0x` to be viem/abitype compatible
* Adds a `Uint8Schema` that takes in string or number and returns an integer